### PR TITLE
Add better error handling

### DIFF
--- a/examples/basic-usage.php
+++ b/examples/basic-usage.php
@@ -60,3 +60,11 @@ $updatedEvent = $future->await();
 $event = new UserCreatedEvent('789', 'user@example.com');
 $future = $dispatcher->dispatch($event, new TimeoutCancellation(30));
 EventLoop::run();
+
+// Set up logging for your dispatcher - all errors will be logged to PSR logger
+$dispatcher = new AsyncEventDispatcher(
+    $listenerProvider,
+    function (Throwable $exception) {
+        error_log($exception->getMessage());
+    }
+);

--- a/src/AsyncEventDispatcher.php
+++ b/src/AsyncEventDispatcher.php
@@ -32,16 +32,16 @@ class AsyncEventDispatcher implements EventDispatcherInterface
 
     /**
      * @param ListenerProviderInterface $listenerProvider The provider of event listeners
-     * @param Closure(Throwable): (void) $errorHandler The handler for errors thrown by listeners
+     * @param callable(Throwable): (void) $errorHandler The handler for errors thrown by listeners
      */
     public function __construct(
         private readonly ListenerProviderInterface $listenerProvider,
-        ?Closure $errorHandler = null
+        ?callable $errorHandler = null
     ) {
         if ($errorHandler === null) {
             $this->errorHandler = function (Throwable $exception): void {};
         } else {
-            $this->errorHandler = $errorHandler;
+            $this->errorHandler = Closure::fromCallable($errorHandler);
         }
     }
 


### PR DESCRIPTION
This PR ads the ability to pass a logger to the disptacher and a config option to let exception bubble up.

## Blocks
- https://github.com/archiprocode/silverstripe-revolt-event-dispatcher/pull/4